### PR TITLE
Use `.` as separator character

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Yeast solves both of these issues by:
 2. Seeding the id in case of collision (when the id is identical to the previous
    one).
 
-To keep the strings unique it will use the `:` char to separate the generated
+To keep the strings unique it will use the `.` char to separate the generated
 stamp from the seed.
 
 ## Installation

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ function yeast() {
   var now = encode(+new Date());
 
   if (now !== prev) return seed = 0, prev = now;
-  return now +':'+ encode(seed++);
+  return now +'.'+ encode(seed++);
 }
 
 //

--- a/test.js
+++ b/test.js
@@ -22,9 +22,9 @@ describe('yeast', function () {
   it('prepends an iterated seed when previous id is the same', function (next) {
     var ids = [yeast(), yeast(), yeast()];
 
-    assume(ids[0]).does.not.include(':');
-    assume(ids[1]).includes(':0');
-    assume(ids[2]).includes(':1');
+    assume(ids[0]).does.not.include('.');
+    assume(ids[1]).includes('.0');
+    assume(ids[2]).includes('.1');
 
     setTimeout(next, 10);
   });
@@ -32,16 +32,16 @@ describe('yeast', function () {
   it('resets the seed', function (next) {
     var ids = [yeast(), yeast(), yeast()];
 
-    assume(ids[0]).does.not.include(':');
-    assume(ids[1]).includes(':0');
-    assume(ids[2]).includes(':1');
+    assume(ids[0]).does.not.include('.');
+    assume(ids[1]).includes('.0');
+    assume(ids[2]).includes('.1');
 
     setTimeout(function () {
       var id = [yeast(), yeast(), yeast()];
 
-      assume(id[0]).does.not.include(':');
-      assume(id[1]).includes(':0');
-      assume(id[2]).includes(':1');
+      assume(id[0]).does.not.include('.');
+      assume(id[1]).includes('.0');
+      assume(id[2]).includes('.1');
 
       setTimeout(next, 10);
     }, 10);


### PR DESCRIPTION
The reason behind this change is that `:` is a reserved URI character.
