### PR TITLE
[minor] Use indexed access to string chars

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_'.split('')
+var alphabet = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-_'
   , length = 64
   , map = {}
   , seed = 0


### PR DESCRIPTION
There is no need to `split()` string into array of chars: string also has indexed access